### PR TITLE
v0.1.2 alpha

### DIFF
--- a/dtl/cli.py
+++ b/dtl/cli.py
@@ -226,6 +226,10 @@ def main():
 		help_cmd(file, cmd, args)
 		exit(0)
 
+	if 'version' in flags:
+		print(f'DTL {VERSION}')
+		exit(0)
+
 	match cmd:
 		case 'parse':
 			parse_cmd(file, args)

--- a/dtl/cli.py
+++ b/dtl/cli.py
@@ -5,7 +5,7 @@ import sys
 from dtl.parse import Parser
 from dtl import ast
 
-VERSION = 'v0.1.1-alpha'
+VERSION = 'v0.1.2-alpha'
 
 def assert_argc(args, count):
 	if len(args) < count:

--- a/dtl/tokenize.py
+++ b/dtl/tokenize.py
@@ -77,6 +77,10 @@ class Lexer:
 						line_indent += 1
 				case 'WS':
 					continue
+				case 'ERROR':
+					print(f'Error: unexpected charachter "{token_val}"')
+					at_line_start = False
+					self.tokens.append(Token(token_type, token_val))
 				case _:
 					at_line_start = False
 					self.tokens.append(Token(token_type, token_val))

--- a/dtl/tokenize.py
+++ b/dtl/tokenize.py
@@ -17,7 +17,7 @@ class Lexer:
 			'AT'       : r'@',
 			'YEAR'     : r'\d{4}',
 			'MONTH'    : r'January|February|March|April|May|June|July|August|September|October|November|December',
-			'DATE'     : r'([2-3]?1st|2?2nd|2?3rd|[1-2]?[3-9]th|30th|11th|12th|13th)',
+			'DATE'     : r'([2-3]?1st|2?2nd|2?3rd|[1-2]?[3-9]th|[1-3]0th|11th|12th|13th)',
 			'DAY'      : r'Mon(day)|Tue(sday)|Wed(esday)|Thu(rsday)|Fri(day)|Sat(urday)|Sun(day)',
 			'TIME'     : r'\d?\d:\d\d(-\d?\d:\d\d)?',
 			'DURATION' : r'([0-9]+\s(seconds|minutes|hours))|(second|minute|hour)',


### PR DESCRIPTION
Added `--version` flag.
Fixed bug in tokenizer that caused `10th` and `20th` to not be recognized as `DATE` tokens.