### PR TITLE
Fix format sorting order

### DIFF
--- a/dtl/ast.py
+++ b/dtl/ast.py
@@ -52,6 +52,8 @@ class File:
 
 		self.segments = defaultdict(list, {k: v['tagged'] + filter_empty(v['merged']) for k, v in self.segments.items()})
 
+		self.segments = defaultdict(list, dict(sorted(self.segments.items())))
+
 		for sub_time in self.segments.keys():
 			for segment in self.segments[sub_time]:
 				segment.validate(header_time)

--- a/dtl/cli.py
+++ b/dtl/cli.py
@@ -6,7 +6,7 @@ from dtl.parse import Parser
 from dtl import ast
 from collections import defaultdict
 
-VERSION = 'v0.1.5-alpha'
+VERSION = 'v0.1.6-alpha'
 
 def assert_argc(args, count):
 	if len(args) < count:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as file:
 
 setup(
 	name='DTL',
-	version='0.1.5',
+	version='0.1.6',
 	author='Joel Niemela',
 	author_email='joel@niemela.se',
 	long_description=long_description,

--- a/test.dtl
+++ b/test.dtl
@@ -1,11 +1,5 @@
 for 2022:
 
-@September 1st 21:54-September 1st 21:55 [X]
-@September 1st 21:54-September 1st 21:55 [X]
-@September 1st 21:54-September 1st 21:55 [X]
-@September 1st 21:54-September 1st 21:55 [X]
-@September 1st 21:54-September 1st 21:55 [X]
-@September 1st 21:54-September 1st 21:55 [X]
 @August
 	@7th
 		!test []
@@ -32,5 +26,11 @@ for 2022:
 @September 1st 21:38 [A]
 @September 1st 21:43-September 1st 21:50 [X]
 @September 1st 21:52-September 1st 21:52 [X]
+@September 1st 21:54-September 1st 21:55 [X]
+@September 1st 21:54-September 1st 21:55 [X]
+@September 1st 21:54-September 1st 21:55 [X]
+@September 1st 21:54-September 1st 21:55 [X]
+@September 1st 21:54-September 1st 21:55 [X]
+@September 1st 21:54-September 1st 21:55 [X]
 @September 1st 21:54-September 1st 21:55 [X]
 @September 1st 21:54-September 1st 21:55 [X]


### PR DESCRIPTION
Bugfix:
- Fixes a bug where `dtl format` wouldn't sort top-level events.