### PR TITLE
Add DTL config file

### DIFF
--- a/dtl/cli.py
+++ b/dtl/cli.py
@@ -5,11 +5,14 @@ import os
 
 from dtl.parse import Parser
 from dtl import ast
+from dtl.config import load_config
+
 from collections import defaultdict
 
 VERSION = 'v0.1.6-alpha'
 
-DTL_dir = os.path.expanduser('~/.DTL/')
+config = load_config(os.path.expanduser('~/.config/DTL/config.ini'))
+DTL_dir = config['DTL_dir']
 
 def assert_argc(args, count):
 	if len(args) < count:

--- a/dtl/config.py
+++ b/dtl/config.py
@@ -3,7 +3,7 @@ import os
 
 def load_config(config_path):
 	config = configparser.ConfigParser()
-	config.read(config_path)
+	config.read(config_path, encoding='utf-8')
 
 	if not config.has_section('DTL'):
 		config.add_section('DTL')

--- a/dtl/config.py
+++ b/dtl/config.py
@@ -1,0 +1,13 @@
+import configparser
+import os
+
+def load_config(config_path):
+	config = configparser.ConfigParser()
+	config.read(config_path)
+
+	if not config.has_section('DTL'):
+		config.add_section('DTL')
+
+	return {
+		'DTL_dir': os.path.expanduser(config.get('DTL', 'DTL_dir', fallback='~/.DTL/')),
+	}


### PR DESCRIPTION
closes #10

DTL now reads a config file at `~/.config/DTL/config.ini`.